### PR TITLE
Fix Worker decode and optional mapping

### DIFF
--- a/WorkersList.swift
+++ b/WorkersList.swift
@@ -1,94 +1,45 @@
-//
-//  WorkersListView.swift
-//  YourAppName
-//
-//  Created by You on YYYY/MM/DD.
-//
-
 import SwiftUI
 
-/// Modell für deine Locations (aus dem Backend)
-struct LocationModel: Codable, Identifiable {
-    let locationID: Int
-    let locationName: String
-    
-    // Für SwiftUI Identifiable
-    var id: Int { locationID }
-}
-
+/// Displays all workers with their current location fetched from the backend
 struct WorkersListView: View {
-    @State private var locations: [LocationModel] = []
-    @State private var errorMessage: String?
+    @StateObject private var viewModel = WorkersListViewModel()
 
     var body: some View {
         NavigationStack {
             Group {
-                if let error = errorMessage {
+                if let error = viewModel.errorMessage {
                     Text("Fehler: \(error)")
                         .foregroundColor(.red)
                         .multilineTextAlignment(.center)
                         .padding()
-                } else if locations.isEmpty {
-                    ProgressView("Lade Standorte…")
+                } else if viewModel.allWorkers.isEmpty {
+                    ProgressView("Lade Mitarbeiter…")
                 } else {
-                    List(locations) { loc in
-                        Text(loc.locationName)
+                    List(viewModel.filteredWorkers) { worker in
+                        HStack {
+                            VStack(alignment: .leading) {
+                                Text(worker.userName)
+                                Text(worker.locationName ?? "Abwesend")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
                     }
                     .listStyle(.plain)
                 }
             }
-            .navigationTitle("Standorte")
+            .navigationTitle("Mitarbeiter")
+            .searchable(text: $viewModel.searchText)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Refresh") {
-                        loadLocations()
+                    Picker("Sort", selection: $viewModel.sortOption) {
+                        ForEach(SortOption.allCases) { opt in
+                            Text(opt.rawValue).tag(opt)
+                        }
                     }
                 }
-            }
-        }
-        .onAppear(perform: loadLocations)
-    }
-
-    private func loadLocations() {
-        errorMessage = nil
-        locations = []
-
-        // localhost im Simulator, LAN‑IP auf echtem Gerät
-        #if targetEnvironment(simulator)
-        let host = "localhost"
-        #else
-        let host = "172.16.42.23"
-        #endif
-
-        guard let url = URL(string: "http://\(host):3000/web/allLocations") else {
-            errorMessage = "Ungültige URL"
-            return
-        }
-
-        APIClient.shared.getJSON(url) { result in
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let json):
-                    guard let arr = json as? [[String: Any]] else {
-                        errorMessage = "Ungültiges JSON-Format"
-                        return
-                    }
-                    locations = arr.compactMap { dict in
-                        guard
-                            let id   = dict["locationID"]  as? Int,
-                            let name = dict["locationName"] as? String
-                        else { return nil }
-                        return LocationModel(locationID: id,
-                                             locationName: name)
-                    }
-                case .failure(let err):
-                    if let urlErr = err as? URLError {
-                        errorMessage = "Network Error: \(urlErr.code)"
-                        print("🔴 URLError:", urlErr)
-                    } else {
-                        errorMessage = err.localizedDescription
-                        print("🔴 Error:", err)
-                    }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Refresh") { viewModel.loadWorkers() }
                 }
             }
         }

--- a/WorklistModel.swift
+++ b/WorklistModel.swift
@@ -3,11 +3,48 @@ import Combine
 
 
 
+/// Employee representation returned by `/web/all-user-current-location`
 struct Worker: Codable, Identifiable {
     let userID: Int
     let userName: String
     var locationName: String?
+
     var id: Int { userID }
+
+    enum CodingKeys: String, CodingKey {
+        case userID = "userId"
+        case userName = "name"
+        case currentLocation
+    }
+
+    enum LocationKeys: String, CodingKey {
+        case locationId
+        case locationName
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        userID = try container.decode(Int.self, forKey: .userID)
+        userName = try container.decode(String.self, forKey: .userName)
+
+        if let locContainer = try? container.nestedContainer(keyedBy: LocationKeys.self,
+                                                             forKey: .currentLocation) {
+            locationName = try locContainer.decode(String.self, forKey: .locationName)
+        } else {
+            locationName = nil
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(userID, forKey: .userID)
+        try container.encode(userName, forKey: .userName)
+        if let name = locationName {
+            var loc = container.nestedContainer(keyedBy: LocationKeys.self,
+                                               forKey: .currentLocation)
+            try loc.encode(name, forKey: .locationName)
+        }
+    }
 }
 
 enum SortOption: String, CaseIterable, Identifiable {
@@ -16,11 +53,13 @@ enum SortOption: String, CaseIterable, Identifiable {
     var id: Self { self }
 }
 
-// J json decoder
-func decodeMitarbeiter() -> [Worker] {
-    let url  = Bundle.main.url(forResource: "Mitarbeiter", withExtension: "json")!
-    let data = try! Data(contentsOf: url)
-    return try! JSONDecoder().decode([Worker].self, from: data)
+// Backend host helper for simulator/real device
+private var backendHost: String {
+#if targetEnvironment(simulator)
+    return "localhost"
+#else
+    return "172.16.42.23"
+#endif
 }
 
 
@@ -31,6 +70,7 @@ final class WorkersListViewModel: ObservableObject {
     @Published var searchText: String = ""
     
     @Published private(set) var allWorkers: [Worker] = []
+    @Published var errorMessage: String?
     
     // sfilter plius sortier funktion
     var filteredWorkers: [Worker] {
@@ -56,8 +96,36 @@ final class WorkersListViewModel: ObservableObject {
     init() {
         loadWorkers()
     }
-    
-    private func loadWorkers() {
-        allWorkers = decodeMitarbeiter()
+
+    /// Loads workers with their current location from the backend.
+    func loadWorkers() {
+        errorMessage = nil
+        allWorkers = []
+
+        guard let url = URL(string: "http://\(backendHost):3000/web/all-user-current-location") else {
+            errorMessage = "Ungültige URL"
+            return
+        }
+
+        APIClient.shared.getJSON(url) { result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success(let json):
+                    guard let arr = json as? [[String: Any]] else {
+                        self.errorMessage = "Ungültiges JSON-Format"
+                        return
+                    }
+                    self.allWorkers = arr.compactMap { dict -> Worker? in
+                        guard let id = dict["userId"] as? Int,
+                              let name = dict["name"] as? String else { return nil }
+
+                        let locName = (dict["currentLocation"] as? [String: Any])?["locationName"] as? String
+                        return Worker(userID: id, userName: name, locationName: locName)
+                    }
+                case .failure(let err):
+                    self.errorMessage = err.localizedDescription
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- implement `encode(to:)` for `Worker` so it conforms to `Codable`
- return optional worker during backend parsing to avoid type mismatch

## Testing
- `swiftc -parse WorklistModel.swift`
- `swiftc -parse *.swift`


------
https://chatgpt.com/codex/tasks/task_e_6888862afa308326bd16649ce1e21988